### PR TITLE
Sales enablement added to launch template

### DIFF
--- a/.github/ISSUE_TEMPLATE/launch-plan.md
+++ b/.github/ISSUE_TEMPLATE/launch-plan.md
@@ -46,7 +46,7 @@ _PMM should take the lead on adding additional marketing activities_
 -   [ ] Draft content and brief website team - _PMM_
 -   [ ] Decide beta reward — _Team lead & PMM_
 -   [ ] For new products: Add email onboarding content and adjust marketing flows - _PMM_
--   [ ] For new products: Create a sales enablement and add to [the repo](https://github.com/PostHog/sales-enablement) - _PMM_
+-   [ ] For new products: Create a sales enablement and add to GTM academy - _PMM_
 
 ### Launch day
 


### PR DESCRIPTION
As the bench of products gets deeper, we're going to need to maintain a library of sales enablement. 

The repo I've setup is barebones for now, but will be growing over time. 

This tweak puts it on the launch checklist for new products. 