### PR TITLE
Add PR template prompting authors to consider if RFC should be private

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,7 @@
+## Summary
+
+_What is this PR proposing or changing?_
+
+## Checklist
+
+- [ ] I have considered whether this RFC should instead be private, and confirmed it's appropriate for this public repo. (See the README — this repo is for non-product discussions that are safe to have in public. If the topic touches anything customer-sensitive, commercially sensitive, or otherwise non-public, it likely belongs in a private venue instead.)


### PR DESCRIPTION
## Summary

Adds `.github/pull_request_template.md` so every PR opened against this repo pre-fills with a short Summary section plus a checklist item asking the author to confirm they've considered whether their RFC should instead live in a private venue.

This repo is explicitly for **public** non-product discussions (per the README), and PostHog has separate venues for anything customer-sensitive, commercially sensitive, or otherwise non-public. Once a PR is opened here the content is public, so the template's job is to make the author pause and make that call deliberately.

## Checklist

- [x] I have considered whether this RFC should instead be private, and confirmed it's appropriate for this public repo.