### PR TITLE
Update to messaging template

### DIFF
--- a/.github/ISSUE_TEMPLATE/Messaging template.md
+++ b/.github/ISSUE_TEMPLATE/Messaging template.md
@@ -1,7 +1,6 @@
 ---
 name: Email or customer messaging
-about: A template to help you gather feedback and increase visibility on email campaigns
-    and other sorts of customer messaging.
+about: A template to help you gather feedback and increase visibility on email campaigns and other sorts of customer messaging.
 title: 'Messaging:'
 labels: marketing
 assignees: ''
@@ -10,21 +9,40 @@ assignees: ''
 # Messaging
 
 ### Context
-
-_What are we sending and why?_
+_What are we sending and why? Explain briefly and link to relevant PRs or issues._
 
 ### Format
+- [ ] Single email broadcast (e.g. a newsletter)
+- [ ] Multiple email broadcasts (e.g. a notification and reminder)
+- [ ] Automated email campaign (e.g. logic-based flow)
+- [ ] Requires in-app notification
+- [ ] Requires social media support
 
-_Is this a broadcast, or campaign? From Workflows, or Customer.io?_
+_Should this be formatted as a marketing email, transactional email, personal email, etc._
 
-### Audience / Targeting
+### Timeline
+_Is there a firm deadline or timeline?_
 
-_Who will see it?_
+> 💡 For changes to T&Cs, DPA, BAA, or other legal documents, expect to give **30 days notice** unless legal advises otherwise. Plan accordingly.
 
-### Boring organization bit
+### Targeting
+_If you're targeting a specific list of customers, add a link to a PostHog cohort of these users or orgs._
+_If this is a major announcement or legal notice, be clear about which orgs, regions and user roles will be messaged._
 
--   [ ] I've added this to [The Messaging Calendar](https://calendar.google.com/calendar/embed?src=c_7ed0dfed00c9a18dbf04d93e633a974f2f2e5172f00673aba3fdb2957baff521%40group.calendar.google.com&ctz=Europe%2FLondon) with a link to this issue
+> 💡 For sensitive messages, the Marketing team will ask in `#group-cs-sales-support` if any managed customers need to be excluded from this comm. 
+
+### Subscription topic
+
+- [ ] Welcome emails
+- [ ] Changelog updates 
+- [ ] Product notifications
+- [ ] Actually useful marketing emails
+- [ ] Service updates
+- [ ] All subscribed and unsubscribed users
+
+### Marketing team checklist
+- [ ] I've added to [The Messaging Calendar](https://calendar.google.com/calendar/embed?src=c_7ed0dfed00c9a18dbf04d93e633a974f2f2e5172f00673aba3fdb2957baff521%40group.calendar.google.com&ctz=Europe%2FLondon) with a link to this issue
+- [ ] I've checked with `#group-cs-sales-support` if any managed customers need to be excluded
 
 ### Requested input and previews
-
 _Dump screenshots here and tag for feedback if needed._

--- a/.github/ISSUE_TEMPLATE/Messaging template.md
+++ b/.github/ISSUE_TEMPLATE/Messaging template.md
@@ -8,6 +8,8 @@ assignees: ''
 
 # Messaging
 
+> This template is for raising messaging plans and requests of issues which we can discuss publicly. If this message involves sensitive information, you should [open a private request instead](https://github.com/PostHog/requests-for-comments-internal/issues/new/choose). 
+
 ### Context
 _What are we sending and why? Explain briefly and link to relevant PRs or issues._
 


### PR DESCRIPTION
## Summary

We've had a few instances where we need to plan comms for sensitive topics, or plan them in a way which involves discussing specific customer data.

We've also had instances where engineers have merged changes without flagging with the legal team, or where the legal team hasn't given clear briefs to marketing.

Most recently: https://posthog.slack.com/archives/C08MYQX74KH/p1777364063781899?thread_ts=1776445803.214799&cid=C08MYQX74KH

This is part of a set of changes to solve this issue.

- [Adds a new handbook section explaining how to engineers should flag issues with legal and how legal can work with marketing](https://github.com/PostHog/posthog.com/pull/16624)
- [Updates the public messaging request template so we can get better information](https://github.com/PostHog/requests-for-comments-public/pull/539)
- [Adds a template for having those conversations in private, when needed](https://github.com/PostHog/requests-for-comments-internal/pull/1087)

## Checklist

- [x] I have considered whether this RFC should instead be private, and confirmed it's appropriate for this public repo. (See the README — this repo is for non-product discussions that are safe to have in public. If the topic touches anything customer-sensitive, commercially sensitive, or otherwise non-public, it likely belongs in a private venue instead.)
