### PR TITLE
Split release and launch plans

### DIFF
--- a/.github/ISSUE_TEMPLATE/launch-plan.md
+++ b/.github/ISSUE_TEMPLATE/launch-plan.md
@@ -1,6 +1,6 @@
 ---
 name: 'Launch Plan'
-about: For planning marketing launches and product announcements.
+about: For planning product releases and marketing launches.
 title: '[Launch Plan] <PRODUCT NAME>'
 labels: marketing
 assignees:
@@ -9,12 +9,17 @@ assignees:
     - PostHog/team-growth
 ---
 
-[PRODUCT NAME] is launching on [MONTH AND DAY]
+[PRODUCT NAME] is **being released** on **[MONTH AND DAY]**
+
+[PRODUCT NAME] is **being launched** on **[MONTH AND DAY]**
+
+> For the distinction between releases and launches, see [releases vs. launches](https://posthog.com/handbook/marketing/product-announcements).
 
 Tag relevant owners here:
 
-Team lead: [@handle]
 Product Marketer (PMM): [@handle]
+Team lead (TL): [@handle]
+Product Manager (PM): [@handle]
 Billing Lead: [@handle]
 Blitzscale: [@handle]
 
@@ -30,48 +35,33 @@ Blitzscale: [@handle]
 
 <!-- PMM is the default fallback for marketing tasks if a specific PMM isn’t assigned. -->
 
-## Launch plan
+## Release plan (primary target: existing users)
 
-_Keep this list current. Link PRs/issues and assign owners._
-_PMM should take the lead on adding additional marketing activities_
+_Optional to fill out. Owned by team lead or PM, see guidance [here](https://posthog.com/handbook/product/releasing-new-products-and-features)_
 
-### Before launch
-
--   [ ] Finalize pricing RFC — _Team lead_ ([template](https://github.com/PostHog/billing/blob/main/notes/pricing-rfc.md))
--   [ ] Create Slack channel **#<product>-launch** with all owners — _PMM_
--   [ ] If needed, create a taskforce for setting a release date. This should be limited to the PMM, PM, and product Team Lead. - _PMM_
--   [ ] Find a case-study customer — _PMM_
--   [ ] Draft content and brief website team - _PMM_
+-   [ ] Create Slack channel **#<product>-launch** with all owners — _TL_, _PM_ or _PMM_
+-   [ ] If needed, create a taskforce for setting a release _and_ launch date. This should be limited to the PMM, PM, and product Team Lead. - _TL_, _PM_ or _PMM_
+-   [ ] Create Slack canvas with a [release checklist](https://posthog.com/handbook/product/releasing-new-products-and-features#releases), incl. rollout plan — _TL_ or _PM_
+-   [ ] Finalize pricing RFC — _TL_ or _PM_ ([template](https://github.com/PostHog/billing/blob/main/notes/pricing-rfc.md))
 -   [ ] Confirm docs are ready — _Docs team_
 -   [ ] Define [product intent](https://posthog.com/handbook/growth/growth-engineering/product-intents) and [activation criteria](https://posthog.com/handbook/growth/growth-engineering/per-product-activation) - _Team lead & PMM_
--   [ ] Draft content and brief website team - _PMM_
--   [ ] Decide beta reward — _Team lead & PMM_
--   [ ] For new products: Add email onboarding content and adjust marketing flows - _PMM_
--   [ ] For new products: Create a sales enablement and add to handbook - _PMM_
--   [ ] For new products: Ensure product is integrated with Wizard - _PMM_
+-   [ ] Decide beta reward — _TL_, _PM_ & _PMM_
 
-### Launch day
+### Release day
 
--   [ ] Merge any remaining PRs — _PMM_
--   [ ] Enable feature flag for all users — _Team lead_
+-   [ ] Migrate organizations to new pricing plans — @PostHog/team-billing
+-   [ ] Roll out feature flag according to the rollout plan — _Team lead_
+-   [ ] Email existing users according to the rollout plan — _PMM_
 -   [ ] Disable beta feedback emails — _PMM_
--   [ ] Create a dedicated channel to centralize support - _PMM_
--   [ ] Release website product page — @corywatilo
--   [ ] Make homepage and nav updates — @corywatilo
--   [ ] Publish announcement on blog if needed - _PMM_
--   [ ] Also publish the blogpost on X as a native article - _PMM_
+-   [ ] Create a dedicated channel to centralize support — _Support team_
 -   [ ] Release in-app onboarding — _Team lead_
--   [ ] Internal announcement for Sales & Ads teams - _PMM_
--   [ ] Ask `#team-growth` to add an ad inside the app to let people know about the product launch - _PMM_
-    -   You should write a custom and personal copy
-    -   You can decide whether everyone gets the product ad or only a set of users (list of emails)
 
 ### Follow-on
 
 -   [ ] Remove early-access feature & feature flags — _Team lead_
--   [ ] If this is a [new product](https://posthog.com/handbook/marketing/product-announcements#new-product-announcements), create and upload a sales enablement doc to [the enablement repo](https://github.com/PostHog/sales-enablement) - _PMM_
--   [ ] Migrate users and delete beta plans — @PostHog/team-billing
 -   [ ] Funnel Zendesk tickets to created Slack channel — _PMM_
+-   [ ] Continue to roll out feature flag according to the rollout plan — _Team lead_
+-   [ ] Continue to email existing users according to the rollout plan — _PMM_
 
 #### Billing changes
 
@@ -81,7 +71,39 @@ _PMM should take the lead on adding additional marketing activities_
 -   [ ] Quota limiting PR — _team lead_ ([example](https://github.com/PostHog/posthog/pull/30459))
 -   [ ] Pricing calculator (site) — _team lead_ ([example](https://github.com/PostHog/posthog.com/pull/11143))
 -   [ ] Set up product and tax codes on Anrok — @PostHog/team-people-and-ops
--   [ ] Add product usage/engagement/mrr tracking to Vitally - @PostHog/team-billing
+-   [ ] Add product usage/engagement/mrr tracking to Vitally — @PostHog/team-billing
+
+___
+
+## Launch plan (primary target: new users)
+
+_Keep this list current. Link PRs/issues and assign owners._
+_PMM should take the lead on adding additional marketing activities_
+
+### Before launch
+
+-   [ ] Find a case-study customer — _PMM_
+-   [ ] Draft content and brief website team — _PMM_
+-   [ ] Draft content and brief website team — _PMM_
+-   [ ] For new products: Add email onboarding content and adjust marketing flows — _PMM_
+-   [ ] For new products: Create a sales enablement and add to handbook — _PMM_
+-   [ ] For new products: Ensure product is integrated with Wizard — _PMM_
+
+### Launch day
+
+-   [ ] Merge any remaining PRs — _PMM_
+-   [ ] Release website product page — @smallbrownbike
+-   [ ] Make homepage and nav updates — @smallbrownbike
+-   [ ] Publish announcement on blog if needed — _PMM_
+-   [ ] Also publish the blogpost on X as a native article — _PMM_
+-   [ ] Internal announcement for Sales & Ads teams — _PMM_
+-   [ ] Ask `#team-growth` to add an ad inside the app to let people know about the product launch — _PMM_
+    -   You should write a custom and personal copy
+    -   You can decide whether everyone gets the product ad or only a set of users (list of emails)
+
+### Follow-on
+
+-   [ ] If this is a [new product](https://posthog.com/handbook/marketing/product-announcements#new-product-announcements), create and upload a sales enablement doc to [the enablement repo](https://github.com/PostHog/sales-enablement) - _PMM_
 
 ## Feedback & ideas
 


### PR DESCRIPTION
## Summary

Splitting the launch checklist into releases & launches as per [Releases vs launches](https://posthog.com/handbook/marketing/product-announcements#releases-vs-launches)
